### PR TITLE
Take command line arguments for old and new paths.

### DIFF
--- a/copy-checker.py
+++ b/copy-checker.py
@@ -1,8 +1,14 @@
 import os
 import hashlib
+import argparse
 
-oldpath = "test-dir/"
-newpath = "test-dir-copy/"
+parser = argparse.ArgumentParser()
+parser.add_argument("oldpath", help="the path to the folder of the original files")
+parser.add_argument("newpath", help="the path to the folder of the copied files")
+args = parser.parse_args()
+
+oldpath = args.oldpath
+newpath = args.newpath
 
 oldfiles = []
 oldroots = []


### PR DESCRIPTION
Rather than having oldpath and newpath be set within the file, instead they are set as command line arguments.